### PR TITLE
rfc1002 rustforge.tar-> rf

### DIFF
--- a/enginelib/src/plugin.rs
+++ b/enginelib/src/plugin.rs
@@ -74,13 +74,9 @@ impl LibraryManager {
                     let path = entry.path();
                     if path.is_file() {
                         if let Some(extension) = path.extension() {
-                            if extension == "tar" {
-                                if let Some(stem) = path.file_stem() {
-                                    if stem.to_string_lossy().ends_with(".rustforge") {
-                                        debug!("Found valid module file: {}", path.display());
-                                        files.push(path.display().to_string());
-                                    }
-                                }
+                            if extension == "rf" {
+                                debug!("Found valid module file: {}", path.display());
+                                files.push(path.display().to_string());
                             }
                         }
                     }
@@ -103,7 +99,9 @@ impl LibraryManager {
         let fs = OxiFS::new(path);
 
         let tmp_path = fs.tempdir.path();
-        #[cfg(unix)]
+        #[cfg(target_os = "macos")]
+        let library_path = tmp_path.join("mod.dylib");
+        #[cfg(all(unix, not(target_os = "macos")))]
         let library_path = tmp_path.join("mod.so");
         #[cfg(windows)]
         let library_path = tmp_path.join("mod.dll");
@@ -141,8 +139,9 @@ impl LibraryManager {
         };
 
         // Version compatibility check
-        if metadata.api_version != crate::GIT_VERSION
-            || metadata.rustc_version != crate::RUSTC_VERSION
+        if std::env::var_os("GE_STRICT_MODS").is_some()
+            && (metadata.api_version != crate::GIT_VERSION
+                || metadata.rustc_version != crate::RUSTC_VERSION)
         {
             let err = format!(
                 "Version mismatch - Module API: {}, Engine API: {}, Module Rustc: {}, Engine Rustc: {}",

--- a/rfc/rfc1002.md
+++ b/rfc/rfc1002.md
@@ -1,0 +1,96 @@
+# RFC 1002: Rustforge Mod Package Format (.rf)
+
+## Summary
+
+This RFC defines the **mod package file format** used by GE Engine. Mods are distributed as a single file with the extension **`.rf`**, placed in the engine’s `./mods/` directory.
+
+`.rf` replaces the legacy `*.rustforge.tar` naming convention. The engine loads **only** `.rf` packages.
+
+## Discovery
+
+- The engine MUST scan the `./mods/` directory at startup.
+- The engine MUST treat any file ending in `.rf` as a mod package candidate.
+- The engine MUST ignore any non-`.rf` files (including `*.rustforge.tar`).
+
+## Container Format
+
+- A `.rf` file MUST be an **uncompressed tar archive**.
+
+### Archive safety constraints
+
+To avoid path traversal and unsafe extraction behavior:
+
+- All archive entries MUST be **relative** paths.
+- Archive entries MUST NOT contain `..` path segments.
+- Archive entries SHOULD NOT be absolute paths.
+
+## Required Layout
+
+A `.rf` archive MUST contain the platform-specific dynamic library at the archive root:
+
+- **Linux**: `mod.so`
+- **Windows**: `mod.dll`
+- **macOS**: `mod.dylib`
+
+Additional files MAY be present and are currently ignored by the engine runtime.
+
+## Module ABI (Exports)
+
+The dynamic library inside the `.rf` archive MUST export the following symbols:
+
+### `metadata`
+
+- Symbol name: `metadata`
+- Signature: `unsafe extern "Rust" fn() -> enginelib::plugin::LibraryMetadata`
+
+### `run`
+
+- Symbol name: `run`
+- Signature: `unsafe extern "Rust" fn(api: &mut enginelib::api::EngineAPI)`
+
+The recommended authoring path is to use the existing proc macros:
+
+- `#[metadata]` to export `metadata`
+- `#[module]` to export `run`
+
+## Compatibility Checks (Strict Mode Only)
+
+`LibraryMetadata` includes the fields:
+
+- `api_version`
+- `rustc_version`
+
+When strict mode is enabled, the engine MUST reject a module when either field does not match the engine build:
+
+- `metadata.api_version != enginelib::GIT_VERSION`
+- `metadata.rustc_version != enginelib::RUSTC_VERSION`
+
+Strict mode is enabled when the environment variable `GE_STRICT_MODS` is set (to any value). If `GE_STRICT_MODS` is not set, these fields are informational and MUST NOT cause the module to be rejected.
+
+## Errors
+
+The engine MUST fail to load a mod package when:
+
+- The required `mod.*` file for the current platform is missing.
+- The required exported symbols (`metadata`, `run`) are missing.
+
+## Examples
+
+Example `.rf` tar contents (Linux):
+
+```
+mod.so
+assets/icon.png
+README.txt
+```
+
+Example `.rf` tar contents (macOS):
+
+```
+mod.dylib
+```
+
+## Migration Note
+
+Mods previously distributed as `*.rustforge.tar` MUST be republished as `*.rf` for the engine to load them.
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the .rf mod package format as the standard for mod packaging and discovery.
  * Added strict mode version compatibility checks, controllable via environment variable.
  * Updated mod loading with platform-specific support.

* **Documentation**
  * Added RFC 1002 documenting the Rustforge Mod Package Format specification, including packaging requirements and safety constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->